### PR TITLE
Fixes for SONARWEB-25

### DIFF
--- a/src/test/java/org/sonar/plugins/web/checks/sonar/AbsoluteURICheckTest.java
+++ b/src/test/java/org/sonar/plugins/web/checks/sonar/AbsoluteURICheckTest.java
@@ -38,7 +38,8 @@ public class AbsoluteURICheckTest {
       .next().atLine(3).withMessage("Replace this absolute URI \"href\" with a relative one, or move this absolute URI to a configuration file.")
       .next().atLine(4).withMessage("Replace this absolute URI \"href\" with a relative one, or move this absolute URI to a configuration file.")
       .next().atLine(7).withMessage("Replace this absolute URI \"src\" with a relative one, or move this absolute URI to a configuration file.")
-      .next().atLine(8).withMessage("Replace this absolute URI \"src\" with a relative one, or move this absolute URI to a configuration file.");
+      .next().atLine(8).withMessage("Replace this absolute URI \"src\" with a relative one, or move this absolute URI to a configuration file.")
+      .next().atLine(9).withMessage("Replace this absolute URI \"src\" with a relative one, or move this absolute URI to a configuration file.");
   }
 
   @Test
@@ -50,7 +51,8 @@ public class AbsoluteURICheckTest {
 
     checkMessagesVerifier.verify(sourceCode.getViolations())
       .next().atLine(7).withMessage("Replace this absolute URI \"src\" with a relative one, or move this absolute URI to a configuration file.")
-      .next().atLine(8).withMessage("Replace this absolute URI \"src\" with a relative one, or move this absolute URI to a configuration file.");
+      .next().atLine(8).withMessage("Replace this absolute URI \"src\" with a relative one, or move this absolute URI to a configuration file.")
+      .next().atLine(9).withMessage("Replace this absolute URI \"src\" with a relative one, or move this absolute URI to a configuration file.");
   }
 
 }

--- a/src/test/java/org/sonar/plugins/web/lex/PageLexerTest.java
+++ b/src/test/java/org/sonar/plugins/web/lex/PageLexerTest.java
@@ -19,6 +19,7 @@ package org.sonar.plugins.web.lex;
 
 import org.junit.Test;
 import org.sonar.channel.CodeReader;
+import org.sonar.plugins.web.node.Attribute;
 import org.sonar.plugins.web.node.CommentNode;
 import org.sonar.plugins.web.node.DirectiveNode;
 import org.sonar.plugins.web.node.Node;
@@ -280,5 +281,33 @@ public class PageLexerTest {
     assertTrue(nodeList.get(1) instanceof TagNode);
     assertTrue(nodeList.get(2) instanceof TextNode);
     assertTrue(nodeList.get(3) instanceof TagNode);
+  }
+
+  @Test
+  public void testAttributeWithoutQuotes() {
+    final StringReader reader = new StringReader("<img src=http://foo/sfds?sjg a=1\tb=2\r\nc=3/>");
+    final PageLexer lexer = new PageLexer();
+    final List<Node> nodeList = lexer.parse(reader);
+
+    assertEquals(1, nodeList.size());
+    assertTrue(nodeList.get(0) instanceof TagNode);
+    final TagNode node = (TagNode)nodeList.get(0);
+    assertEquals(4, node.getAttributes().size());
+
+    final Attribute attribute = node.getAttributes().get(0);
+    assertEquals("src", attribute.getName());
+    assertEquals("http://foo/sfds?sjg", attribute.getValue());
+
+    final Attribute attributeA = node.getAttributes().get(1);
+    assertEquals("a", attributeA.getName());
+    assertEquals("1", attributeA.getValue());
+
+    final Attribute attributeB = node.getAttributes().get(2);
+    assertEquals("b", attributeB.getName());
+    assertEquals("2", attributeB.getValue());
+
+    final Attribute attributeC = node.getAttributes().get(3);
+    assertEquals("c", attributeC.getName());
+    assertEquals("3", attributeC.getValue());
   }
 }

--- a/src/test/resources/checks/absoluteURICheck.html
+++ b/src/test/resources/checks/absoluteURICheck.html
@@ -6,4 +6,4 @@
 <img href="ftp://foo/dfgdfgdfg?dfjgdf=23" />
 <img src="http://foo/sfds?sjg" />
 <img src="ftp://foo/dfgdfgdfg?dfjgdf=23" />
-<img src=http://foo/sfds?sjg /> <!-- False negative -->
+<img src=http://foo/sfds?sjg />


### PR DESCRIPTION
Fixed issue with processing of value of unquoted attributes by replacing the use of the EndTokenMatcher by reading from the CodeReader until the end of the value is detected